### PR TITLE
feat: Add Home screen and Core Data persistence for movies

### DIFF
--- a/MovieAppWithUIKit.xcodeproj/xcuserdata/omerfarukdikili.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/MovieAppWithUIKit.xcodeproj/xcuserdata/omerfarukdikili.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "27D5D21A-1A9D-47F4-A185-B98391164AFA"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "41914FFD-0EE7-4B20-B6E3-DD42A6461315"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "MovieAppWithUIKit/Controller/DownloadsViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "36"
+            endingLineNumber = "36"
+            landmarkName = "getDownloads()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/MovieAppWithUIKit/AppDelegate.swift
+++ b/MovieAppWithUIKit/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -30,6 +31,50 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+        */
+        let container = NSPersistentContainer(name: "MovieLocalModel")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                 
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+
 
 
 }

--- a/MovieAppWithUIKit/Controller/DownloadsViewController.swift
+++ b/MovieAppWithUIKit/Controller/DownloadsViewController.swift
@@ -6,24 +6,67 @@
 //
 
 import UIKit
+import SwiftUI
 
 class DownloadsViewController: UIViewController {
-
+    
+    var downloads : [MovieItem] = []
+    
+    private let downloadTable : UITableView = {
+       var table = UITableView()
+        table.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        return table
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .gray
-        // Do any additional setup after loading the view.
+        view.backgroundColor = .systemBackground
+        view.addSubview(downloadTable)
+        downloadTable.dataSource = self
+        downloadTable.delegate = self
+        getDownloads()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    func getDownloads() {
+        DataPercistenceManager.shared.getAllDownloadedMovies { [weak self] results in
+            switch results {
+            case .failure(let error):
+                print("error")
+            case .success(let movies):
+                self?.downloads = movies
+                DispatchQueue.main.async {
+                    self?.downloadTable.reloadData()
+                }
+            }
+            
+        }
     }
-    */
-
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        downloadTable.frame = view.bounds
+    }
 }
+
+extension DownloadsViewController : UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return downloads.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+       let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = downloads[indexPath.row].original_title
+        return cell
+    }
+}
+
+struct DownloadsViewController_Previews: PreviewProvider {
+    static var previews: some View {
+        UIViewControllerPreview {
+            let downloadVc = DownloadsViewController()
+            return UINavigationController(rootViewController: downloadVc)
+        }
+        .edgesIgnoringSafeArea(.all)
+    }
+}
+

--- a/MovieAppWithUIKit/Controller/HomeViewController.swift
+++ b/MovieAppWithUIKit/Controller/HomeViewController.swift
@@ -28,6 +28,8 @@ class HomeViewController: UIViewController {
     var topRatedMoviewList : [Movie] = []
     var upComingMoviewList : [Movie] = []
     var tvMovieList : [Movie] = []
+    var randomMovie : Movie?
+    var headerView : HeroHeaderUIView?
     let sectionTitle : [String] = ["Trending Movies","Popular","Trending TV","Upcoming Mo","Top rated"]
     
     override func viewDidLoad() {
@@ -42,7 +44,7 @@ class HomeViewController: UIViewController {
         getTopRatedMovies()
         getUpComingMovies()
         getTvMovies()
-        let headerView = HeroHeaderUIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 450))
+        headerView = HeroHeaderUIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 450))
         homeFeedTable.tableHeaderView = headerView
      }
     
@@ -57,6 +59,8 @@ class HomeViewController: UIViewController {
             case .success(let movies):
                 DispatchQueue.main.async {
                     self?.trendingMoviewList = movies
+                    self?.randomMovie = movies.randomElement()
+                    self?.headerView?.configure(with: self?.randomMovie)
                     self?.homeFeedTable.reloadData()
                 }
             case .failure(_):

--- a/MovieAppWithUIKit/Controller/MoviePreviewViewController.swift
+++ b/MovieAppWithUIKit/Controller/MoviePreviewViewController.swift
@@ -69,7 +69,8 @@ class MoviePreviewViewController: UIViewController {
         
         let overViewConstraints: [NSLayoutConstraint] = [
             overviewLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 15),
-            overviewLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+            overviewLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            overviewLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
         ]
         
         let downloadButtonConstraints: [NSLayoutConstraint] = [
@@ -89,7 +90,7 @@ class MoviePreviewViewController: UIViewController {
     
     func configure (with model : MoviePreviewViewModel){
         titleLabel.text = model.title
-        overviewLabel.text = model.title
+        overviewLabel.text = model.titleOverview
         guard let url = URL(string: "https://www.youtube.com/embed/\(model.youtubeView.id.videoId)") else { return }
         youtubeWebView.load(URLRequest(url: url))
         

--- a/MovieAppWithUIKit/Managers/DataPercistenceManager.swift
+++ b/MovieAppWithUIKit/Managers/DataPercistenceManager.swift
@@ -1,0 +1,49 @@
+//
+//  File.swift
+//  MovieAppWithUIKit
+//
+//  Created by Ömer Faruk Dikili on 3.03.2025.
+//
+
+import Foundation
+import UIKit
+import CoreData
+
+class DataPercistenceManager {
+    static let shared = DataPercistenceManager()
+    private init() {}
+    
+    func DownloadMoview(with model : Movie,completeion : @escaping (Result<Void,Error>)->Void){
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        let context = appDelegate.persistentContainer.viewContext
+        let item = MovieItem(context: context)
+        item.original_title = model.original_title
+        item.id = Int64(model.id)
+        item.original_name = model.original_name
+        item.overview = model.overview
+        item.media_type = model.media_type
+        item.poster_path = model.poster_path
+        item.release_date = model.release_date
+        item.vote_count = Int64(model.vote_count)
+        item.vote_average = model.vote_average
+
+        do{
+            try context.save()
+            completeion(.success(()))
+        }catch(let error) {
+            completeion(.failure((error)))
+        }
+    }
+    
+    func getAllDownloadedMovies(completion:@escaping (Result<[MovieItem],Error>) -> Void){
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        let context = appDelegate.persistentContainer.viewContext
+        let request : NSFetchRequest<MovieItem> = MovieItem.fetchRequest()
+        do{
+            let result = try context.fetch(request)
+            completion(.success(result))
+        }catch(let error){
+            completion(.failure(error))
+        }
+    }
+}

--- a/MovieAppWithUIKit/Models/MovieLocalModel.xcdatamodeld/MovieLocalModel.xcdatamodel/contents
+++ b/MovieAppWithUIKit/Models/MovieLocalModel.xcdatamodeld/MovieLocalModel.xcdatamodel/contents
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="MovieItem" representedClassName="MovieItem" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="media_type" optional="YES" attributeType="String"/>
+        <attribute name="original_name" optional="YES" attributeType="String"/>
+        <attribute name="original_title" optional="YES" attributeType="String"/>
+        <attribute name="overview" optional="YES" attributeType="String"/>
+        <attribute name="poster_path" optional="YES" attributeType="String"/>
+        <attribute name="release_date" optional="YES" attributeType="String"/>
+        <attribute name="vote_average" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="vote_count" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/MovieAppWithUIKit/Views/CollectionViewTableViewCell.swift
+++ b/MovieAppWithUIKit/Views/CollectionViewTableViewCell.swift
@@ -57,6 +57,17 @@ class CollectionViewTableViewCell: UITableViewCell {
            collectionView.reloadData()
        }
     
+    private func downloadTitleAt(indexPath:IndexPath){
+        DataPercistenceManager.shared.DownloadMoview(with: items[indexPath.item], completeion: {result in
+            switch result {
+            case .success():
+                print("success")
+            case .failure(_):
+                print("error")
+            }
+        }
+    )}
+    
 }
 
 extension CollectionViewTableViewCell : UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -101,9 +112,27 @@ extension CollectionViewTableViewCell : UICollectionViewDataSource, UICollection
             }
         }
     }
+    
+    func downloadMovie(indexPath:IndexPath){
+        print("Downloading movie at \(indexPath)")
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemsAt indexPaths: [IndexPath], point: CGPoint) -> UIContextMenuConfiguration? {
+        guard let indexPath = indexPaths.first else { return nil }
+
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { suggestedActions in
+            let shareAction = UIAction(title: "Downlaod", image: UIImage(systemName: "square.and.arrow.up")) { [self] action in
+                downloadTitleAt(indexPath: indexPath)
+            }
+
+            let deleteAction = UIAction(title: "Delete", image: UIImage(systemName: "trash"), attributes: .destructive) { action in
+                print("Delete tapped for item at \(indexPath)")
+            }
+
+            return UIMenu(title: "Movie Actions", children: [shareAction, deleteAction])
+        }
+    }
 }
-
-
 
 
 struct CollectionViewCellPreview: UIViewRepresentable {

--- a/MovieAppWithUIKit/Views/HeroHeaderUIView.swift
+++ b/MovieAppWithUIKit/Views/HeroHeaderUIView.swift
@@ -6,11 +6,12 @@
 //
 
 import UIKit
+import SDWebImage
 class HeroHeaderUIView: UIView {
+    
 
     private let heroView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: "heroExampleImage")
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         return imageView
@@ -69,6 +70,16 @@ class HeroHeaderUIView: UIView {
         ]
         gradientLayer.frame = bounds
         layer.addSublayer(gradientLayer)
+    }
+    
+    func configure(with movie:Movie?){
+        guard let posterImage = movie?.poster_path else {
+            return
+        }
+        guard let url = URL(string: "https://image.tmdb.org/t/p/w500/\(posterImage)") else {
+            return
+        }
+        heroView.sd_setImage(with: url,completed: nil)
     }
 
     required init?(coder: NSCoder) {

--- a/MovieAppWithUIKit/Views/MovieCollectionViewCell.swift
+++ b/MovieAppWithUIKit/Views/MovieCollectionViewCell.swift
@@ -39,8 +39,7 @@ class MovieCollectionViewCell: UICollectionViewCell {
         
         guard let url = URL(string: "https://image.tmdb.org/t/p/w500/\(model)") else {
             return
-        }
-        
+        }        
         posterImageView.sd_setImage(with: url, completed: nil)
     }
     


### PR DESCRIPTION
- Implemented HomeViewController to fetch and display movie data
- Added DataPersistenceManager to handle saving movies to Core Data
- Configured table view with multiple sections (Trending, Popular, etc.)
- Integrated HeroHeaderUIView for featured movie display
- Added navigation bar buttons for user profile and play options
- Set up Core Data methods to save and fetch movies
- Linked collection view cells to detailed movie preview screen